### PR TITLE
Potential label key change

### DIFF
--- a/parcellate/model.py
+++ b/parcellate/model.py
@@ -1410,7 +1410,7 @@ def parcellate(
 
                     labeling_dir = get_path(output_dir, 'subdir', 'label', labeling_id)
                     for filename in os.listdir(labeling_dir):
-                        if filename.endswith(suffix) or (not results_copied and filename == PATHS['label']['evaluation']):
+                        if filename.endswith(suffix) or (not results_copied and filename == PATHS['label']['output']):
                             shutil.copy(join(labeling_dir, filename), join(parcellation_dir, filename))
                 else:
                     stderr('%sParcellation exists. Skipping. To re-parcellate, run with overwrite=True.\n' %


### PR DESCRIPTION
I changed the call to `PATHS['label']['evaluation']` on line 1413 of `model.py` to `PATHS['label']['output']` (as `'evaluation'` is not defined in `constants.py`). Not sure what the intended behavior is but I did this in order to run the labeling without error.